### PR TITLE
Update to use bearer tokens, per current Sentry auth.

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = {
         return request({
           uri: releaseUrl,
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true,
         });
@@ -128,7 +128,7 @@ module.exports = {
           uri: this.baseUrl,
           method: 'POST',
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true,
           body: {
@@ -209,7 +209,7 @@ module.exports = {
         return request({
           uri: urljoin(this.releaseUrl, 'files/'),
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
           json: true
         });
@@ -220,7 +220,7 @@ module.exports = {
           uri: urljoin(this.releaseUrl, 'files/', file.id, '/'),
           method: 'DELETE',
           auth: {
-            user: this.sentrySettings.apiKey
+            bearer: this.sentrySettings.apiKey
           },
         });
       },


### PR DESCRIPTION
Uploading sourcemaps to Sentry was failing, due to Sentry expecting a bearer token. I've adjusted the auth options accordingly.

_Per the tradition of my people, every pull request should come with a cute animal picture:_

![high five](https://s-media-cache-ak0.pinimg.com/236x/c1/15/e4/c115e4d4b8eec90ee22a1875ddc18c80.jpg)
